### PR TITLE
Change rebuild_site function to only operate on POST requests

### DIFF
--- a/functions/rebuild_site.js
+++ b/functions/rebuild_site.js
@@ -1,6 +1,9 @@
 const axios = require("axios");
 
 exports.handler = async function(event, context, callback) {
+    if (event.httpMethod !== "POST") {
+        return { statusCode: 404, body: {} }
+    }
     const body = {
         "event_type": "kontent_publish",
         "client_payload": {


### PR DESCRIPTION
HTTP method comes in on the `event` object. Docs here: https://docs.netlify.com/functions/build-with-javascript/#format